### PR TITLE
Lock Cause is not Saved to Database for Stockunits

### DIFF
--- a/dev/los-ejb/src/main/java/de/linogistix/los/inventory/crud/StockUnitCRUDBean.java
+++ b/dev/los-ejb/src/main/java/de/linogistix/los/inventory/crud/StockUnitCRUDBean.java
@@ -63,14 +63,15 @@ public class StockUnitCRUDBean extends BusinessObjectCRUDBean<StockUnit> impleme
 
 	@Override
 	public void lock(StockUnit entity, int lock, String lockCause) throws BusinessObjectSecurityException {
+		User user = context.getCallersUser();
 		if (!context.checkClient(entity)) {
-			User user = context.getCallersUser();
 			throw new BusinessObjectSecurityException(user);
 		}
 
 		try {
 			entity = manager.find(entity.getClass(), entity.getId());
 			inventoryBusiness.addStockUnitLock(entity, lock);
+			entity.addAdditionalContent( "L  "+user.getName() + " : " + lockCause);
 		} catch (FacadeException e) {
 			// Sorry for special exceptions. The real cause will be hidden
 			logger.log(Level.SEVERE, "EXCEPTION="+e.getClass().getSimpleName()+", "+e.getMessage(), e);


### PR DESCRIPTION
@wms2: Somehow comments made in the Client are not saved for Stockunits in `dev/los-ejb/src/main/java/de/linogistix/los/inventory/crud/StockUnitCRUDBean.java`. Mirrored  behaviour from default implementation in `dev/los-ejb/src/main/java/de/linogistix/los/crud/BusinessObjectCRUDBean.java`. This might not be the most elegant Solution, but it works.